### PR TITLE
Add Generic instance for View for higher kinded records

### DIFF
--- a/vessel.cabal
+++ b/vessel.cabal
@@ -25,6 +25,7 @@ library
                      , dependent-sum
                      , dependent-sum-aeson-orphans
                      , monoidal-containers
+                     , mtl
                      , reflex >= 0.6
                      , these
                      , QuickCheck


### PR DESCRIPTION
This lets you write `View` types that look like this:

```
data MyView f = MyView
  { _myView_foo :: MapV Int Int f
  , _myView_bar :: MapV Text Text f
  } deriving (Generic, View)
```

instead of using `Vessel`. Sometimes this is nicer to work with and it should have better performance as well.