### PR TITLE
Remove Group/Additive orphans for Const which are now in patch

### DIFF
--- a/src/Data/Vessel.hs
+++ b/src/Data/Vessel.hs
@@ -792,12 +792,6 @@ instance (Has' Group f g, Has' Semigroup f g, GCompare f) => Group (MonoidalDMap
 
 instance (Has' Group f g, Has' Semigroup f g, GCompare f) => Additive (MonoidalDMap f g)
 
-instance Group g => Group (Const g x) where
-  negateG (Const a) = Const (negateG a)
-  (Const a) ~~ (Const b) = Const (a ~~ b)
-
-instance Additive g => Additive (Const g x)
-
 instance (Semigroup (f (g a))) => Semigroup (Compose f g a) where
   (Compose x) <> (Compose y) = Compose (x <> y)
 

--- a/vessel.cabal
+++ b/vessel.cabal
@@ -31,7 +31,7 @@ library
                      , dependent-sum-aeson-orphans >= 0.2.1 && < 0.3
                      , monoidal-containers >= 0.6 && < 0.7
                      , mtl >= 2.2 && < 2.3
-                     , reflex >= 0.6.2.4 && < 0.7
+                     , reflex >= 0.6.4 && < 0.7
                      , semialign >= 1
                      , these >= 1 && < 1.1
                      , QuickCheck >= 2.12 && < 2.14


### PR DESCRIPTION
This is needed for compatibility with latest reflex.