### PR TITLE
Add another orphan instance for Compose

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,3 +3,7 @@
 ## 0.1.0.0
 
 * Initial release
+
+## 0.1.1.0
+
+* Add an orphan instance for 'Additive' of 'Compose' this is in line with the other orphans for 'Compose' that will be phased out in a future release in favor of an upstream solution.

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+optional-packages:
+  *
+write-ghc-environment-files: never

--- a/src/Data/Vessel/Internal.hs
+++ b/src/Data/Vessel/Internal.hs
@@ -96,6 +96,8 @@ instance (Monoid (f (g a))) => Monoid (Compose f g a) where
   mempty = Compose mempty
   mappend (Compose x) (Compose y) = Compose (mappend x y)
 
+instance (Additive (f (g a))) => Additive (Compose f g a)
+
 ------- Miscellaneous stuff to be moved elsewhere -------
 
 -- TODO: These belong in Data.Functor.Compose -- good luck to anyone who wants to upstream them into base though.

--- a/vessel.cabal
+++ b/vessel.cabal
@@ -1,5 +1,5 @@
 name:               vessel
-version:            0.1.0.0
+version:            0.1.1.0
 description:
   A dependently-typed key-value data structure that allows for storage of both "queries", (wherein keys are stored along with reasons for selecting the items or counts of the number of times something has been selected), as well as the responses to those queries, in which the type of the key additionally determines the type of the response
 


### PR DESCRIPTION
This instance is more in the same vein as the other Compose orphans in the same place, to make Vessels usable with obelisk/rhyolite.

I've also added a cabal.project file so that it's easier to work with Vessel as a dep inside of a larger project.

@Ericson2314 told me a bunch of stuff about how this is fucked up in base upstream. I have to go through his notes and  turn them into a plan that deals with this situation properly. :)