### PR TITLE
Fix the build by pulling in base-orphans properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+result
+tags

--- a/reflex-platform/github.json
+++ b/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
+  "branch": "release/0.9.2.0",
   "private": false,
-  "rev": "6c2636422a6c721e26481ac5901fb0d359922a90",
-  "sha256": "1axnpqfwzprszfzlab3gk9x3pmd2fhdnjwf4xw9v5k8j9p2j7lv0"
+  "rev": "123a6f487ca954fd983f6d4cd6b2a69d4c463d10",
+  "sha256": "16q1rq0rwi6l28fv46q8m0hvb9rxrzf574j865vaz04xy8d5p1ya"
 }

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,10 @@
-let rp = import ./reflex-platform {};
+let
+  haskellOverlaysPost = [
+    (self: super: {
+      base-orphans = self.callHackage "base-orphans" "0.8.5" {};
+    })
+  ];
+  rp = import ./reflex-platform { inherit haskellOverlaysPost; };
 in
 { ghc = rp.ghc.callCabal2nix "vessel" ./. {};
   ghcjs = rp.ghcjs.callCabal2nix "vessel" ./. {};

--- a/vessel.cabal
+++ b/vessel.cabal
@@ -48,6 +48,7 @@ library
   build-depends:
       aeson                        >=1.4     && <1.6
     , base                         >=4.9     && <4.15
+    , base-orphans                 ^>=0.8.5
     , bifunctors                   ^>=5.5
     , constraints                  >=0.10    && <0.15
     , constraints-extras           ^>=0.3


### PR DESCRIPTION
Our nix-based CI failed but the github actions succeeded. This is confusing because base-orphans was omitted from the cabal file. In any case, this PR bumps reflex-platform and overrides base-orphans to pull in a fresh enough version from the hackage snapshot to properly build with nix.