### PR TITLE
Change DMapV's implementation to use `:.:` instead of `Compose`.

### DIFF
--- a/src/Data/Vessel/Internal.hs
+++ b/src/Data/Vessel/Internal.hs
@@ -43,6 +43,7 @@ import Data.Set (Set)
 import Data.Witherable
 import qualified Data.Map as Map'
 import qualified Data.Map.Merge.Strict as Map'
+import GHC.Generics
 
 import qualified Data.Dependent.Map.Monoidal as DMap
 -- import qualified Data.Dependent.Map as DMap'
@@ -100,6 +101,12 @@ assocLCompose (Compose x) = Compose (Compose (fmap getCompose x))
 
 assocRCompose :: (Functor f) => Compose (Compose f g) h x -> Compose f (Compose g h) x
 assocRCompose (Compose (Compose x)) = Compose (fmap Compose x)
+
+assocLComposeComp :: (Functor f) => (Compose f (g :.: h)) x -> ((Compose f g) :.: h) x
+assocLComposeComp (Compose x) = Comp1 $ Compose (fmap unComp1 x)
+
+assocRComposeComp :: (Functor f) => ((Compose f g) :.: h) x -> Compose f (g :.: h) x
+assocRComposeComp (Comp1 (Compose x)) = Compose (fmap Comp1 x)
 
 alignWithKeyMaybeDMap :: GCompare k => (forall a. k a -> These (f a) (g a) -> Maybe (h a)) -> DMap k f -> DMap k g -> DMap k h
 alignWithKeyMaybeDMap f a b = DMap'.mapMaybeWithKey (\k t -> f k $ dtheseToThese t) $ DMap'.unionWithKey (\_ (DThis x) (DThat y) -> DThese x y) (DMap'.map DThis a) (DMap'.map DThat b)


### PR DESCRIPTION
The latter has a lot of baggage regarding instances. For example, to get
Eq for a Compose structure one will rely on the Eq1 class. It's very
frequently the case that we do not want to use this class because it
cannot be easily generated for GADTs.

Vessel is already using `constraints-extras` extensively to wrangle
instances for such GADTs and :.: is more neutral about how instances are
fulfilled based on the constituent pieces. For example compare the two:

`Eq (f (g p)) => Eq ((f :.: g) p)`

`(Eq1 f, Eq1 g, Eq a) => Eq (Compose f g a)`

The former will be easier to write by hand with constraints-extras's
`ArgDict` which can be generated for you.