### PR TITLE
Give `Vessel` and `DMapV` more polymorphic kinds.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for vessel
 
+## 0.2.2.0
+
+* Allow `Vessel` and `DMapV` types to be more liberally kinded in their indexes.
+
 ## 0.2.1.0
 
 * Add Data.Vessel.Path. See that module for documentation.

--- a/release.nix
+++ b/release.nix
@@ -2,6 +2,7 @@ let
   haskellOverlaysPost = [
     (self: super: {
       base-orphans = self.callHackage "base-orphans" "0.8.5" {};
+      dependent-sum-aeson-orphans = self.callHackage "dependent-sum-aeson-orphans" "0.3.1.0" {};
     })
   ];
   rp = import ./reflex-platform { inherit haskellOverlaysPost; };

--- a/src/Data/Vessel/Class.hs
+++ b/src/Data/Vessel/Class.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.Vessel.Class where
 
@@ -59,7 +60,7 @@ import Data.Vessel.Internal
 --
 -- It also specifies the cropV operation which restricts a view to a particular selection, as well
 -- as operations for mapping functions over all the leaves of the container.
-class View (v :: (* -> *) -> *) where
+class View (v :: (x -> *) -> *) where
   -- | Transpose a sufficiently-Map-like structure into a container, effectively aggregating
   -- many structures into a single one containing information about which keys each part of it
   -- came from originally.

--- a/src/Data/Vessel/DependentMap.hs
+++ b/src/Data/Vessel/DependentMap.hs
@@ -45,7 +45,7 @@ import Data.Vessel.Selectable
 import Data.Vessel.Internal
 
 -- | A functor-indexed container corrresponding to DMap k v.
-newtype DMapV (k :: * -> *) (v :: * -> *) g = DMapV { unDMapV :: MonoidalDMap k (g :.: v) }
+newtype DMapV (k :: x -> *) (v :: x -> *) g = DMapV { unDMapV :: MonoidalDMap k (g :.: v) }
   deriving (Generic)
 
 deriving instance (GCompare k, Has' Eq k (g :.: v)) => Eq (DMapV k v g)

--- a/src/Data/Vessel/Internal.hs
+++ b/src/Data/Vessel/Internal.hs
@@ -67,7 +67,7 @@ instance Additive (v g) => Additive (FlipAp g v)
 
 
 -- A single Vessel key/value pair, essentially a choice of container type, together with a corresponding container.
-data VSum (k :: ((* -> *) -> *) -> *) (g :: * -> *) = forall v. k v :~> v g
+data VSum (k :: ((x -> *) -> *) -> *) (g :: x -> *) = forall v. k v :~> v g
 
 ------- Serialisation -------
 

--- a/src/Data/Vessel/Vessel.hs
+++ b/src/Data/Vessel/Vessel.hs
@@ -58,13 +58,17 @@ import Data.Vessel.ViewMorphism
 -- discussed above, keyed by a GADT whose index will specify which sort of container goes in each position.
 --
 -- Ordinary types with values have kind *
--- Functors have kind * -> *
--- Containers taking a functor as a parameter then have kind (* -> *) -> *
--- The keys of a vessel are indexed by a functor-parametric container type, so they have kind ((* -> *) -> *) -> *
+-- Functors have kind k -> *
+-- Containers taking a functor as a parameter then have kind (k -> *) -> *
+-- The keys of a vessel are indexed by a functor-parametric container type, so they have kind ((k -> *) -> *) -> *
 -- Vessel itself, for any such key type, produces a functor-parametric container, so it has kind
+-- (((k -> *) -> *) -> *) -> (k -> *) -> *
+--
+-- The majority of use cases will be working entirely within * so that Vessel will be instantiated to the kind
 -- (((* -> *) -> *) -> *) -> (* -> *) -> *
+--
 -- Law: None of the items in the Vessel's MonoidalDMap are nullV
-newtype Vessel (k :: ((* -> *) -> *) -> *) (g :: * -> *) = Vessel { unVessel :: MonoidalDMap k (FlipAp g) }
+newtype Vessel (k :: ((x -> *) -> *) -> *) (g :: x -> *) = Vessel { unVessel :: MonoidalDMap k (FlipAp g) }
   deriving (Generic)
 
 deriving instance (GCompare k, Has' Eq k (FlipAp g)) => Eq (Vessel k g)

--- a/vessel.cabal
+++ b/vessel.cabal
@@ -1,5 +1,5 @@
 name:               vessel
-version:            0.2.1.0
+version:            0.2.2.0
 description:
   A dependently-typed key-value data structure that allows for storage of both "queries", (wherein keys are stored along with reasons for selecting the items or counts of the number of times something has been selected), as well as the responses to those queries, in which the type of the key additionally determines the type of the response
 
@@ -56,7 +56,7 @@ library
     , dependent-map                ^>=0.4
     , dependent-monoidal-map       ^>=0.1.1.0
     , dependent-sum                ^>=0.7
-    , dependent-sum-aeson-orphans  ^>=0.3
+    , dependent-sum-aeson-orphans  ^>=0.3.1
     , monoidal-containers          ^>=0.6
     , mtl                          ^>=2.2
     , patch                        ^>=0.0.4.0


### PR DESCRIPTION
In particular for `Vessel`, its second parameter can be `x -> *` for any
`x` and therefore its first parameter has kind `(x -> *) -> *) -> *`.

For `DMapV` both the key and value functor parameters can use any kind
as index, so their kinds are `x -> *` for any `x`.

This is a minor enhancement but a useful one. The indexes don't actually
play a part in any of the data manipulation and in some use cases there
is a convenient kind to index over that is not *.